### PR TITLE
Fix metadata and add outputs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ aws apprunner create-service --service-name ${SERVICE_NAME} \
     --source-configuration file://hello-app-runner.json
 ```
 
+If you want to deploy and manage this container using AWS CloudFormation just run
+
+```bash
+SERVICE_NAME=hello-app-runner
+
+aws cloudformation create-stack --template-body file://cf.yaml --stack-name ${SERVICE_NAME} --parameters "ParameterKey=ServiceName,ParameterValue=${SERVICE_NAME}"
+```
+
 ## Features
 
 The service exposes a basic splash page with links to relevant App Runner content.

--- a/cf.yaml
+++ b/cf.yaml
@@ -5,7 +5,7 @@ Description: CloudFormation template that deploys hello-app-runner app
 Resources:
   Service:
     Metadata:
-      'hello-app-runner example service'
+      'aws:apprunner:description': 'hello-app-runner example service'
     Type: AWS::AppRunner::Service
     Properties:
       ServiceName: hello-app-runner
@@ -16,3 +16,7 @@ Resources:
           ImageRepositoryType: ECR_PUBLIC
           ImageConfiguration:
             Port: 8000
+Outputs:
+  Endpoint:
+    Description: "The endpoint of the App Runner service."
+    Value: !GetAtt Service.ServiceUrl

--- a/cf.yaml
+++ b/cf.yaml
@@ -1,0 +1,18 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template that deploys hello-app-runner app
+Resources:
+  Service:
+    Metadata:
+      'hello-app-runner example service'
+    Type: AWS::AppRunner::Service
+    Properties:
+      ServiceName: hello-app-runner
+      SourceConfiguration:
+        AutoDeploymentsEnabled: false
+        ImageRepository:
+          ImageIdentifier: public.ecr.aws/aws-containers/hello-app-runner:latest
+          ImageRepositoryType: ECR_PUBLIC
+          ImageConfiguration:
+            Port: 8000

--- a/cf.yaml
+++ b/cf.yaml
@@ -2,13 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 AWSTemplateFormatVersion: 2010-09-09
 Description: CloudFormation template that deploys hello-app-runner app
+Parameters:
+  ServiceName:
+    Type: String
+    Default: hello-app-runner
+    Description: Name for your App Runner service.
 Resources:
   Service:
     Metadata:
       'aws:apprunner:description': 'hello-app-runner example service'
     Type: AWS::AppRunner::Service
     Properties:
-      ServiceName: hello-app-runner
+      ServiceName: !Ref ServiceName
       SourceConfiguration:
         AutoDeploymentsEnabled: false
         ImageRepository:


### PR DESCRIPTION
This PR fixes `Metadata` section and adds `Outputs` section to obtain the endpoint of the deployed App Runner service.