### PR TITLE
Update requirements.txt to fix old dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ starlette==0.14.2
 starlette-exporter==0.7.0
 uvicorn==0.13.4
 Jinja2==2.11.3
+MarkupSafe==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.25.1
 starlette==0.14.2
 starlette-exporter==0.7.0
 uvicorn==0.13.4
+Jinja2==2.11.3

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
 <meta property="og:image:width" content="1200"/>
 <meta property="og:image:height" content="630"/>
 
-<title>Hello AWS App Runner V2</title>
+<title>Hello AWS App Runner</title>
 <style>
 
 /* open-sans-regular - latin */
@@ -181,7 +181,7 @@ html, body {
 			<img class="apprunner_icon" src="{{ full_url ~ 'static/apprunner_icon.svg' }}" />
 		</div>
 
-		<h1>And we're live! V2</h1>
+		<h1>And we're live!</h1>
 		<div class="metadata">
 			<p>
         {% if ( '0.0' in full_url or 'localhost' in full_url )  %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
 <meta property="og:image:width" content="1200"/>
 <meta property="og:image:height" content="630"/>
 
-<title>Hello AWS App Runner</title>
+<title>Hello AWS App Runner V2</title>
 <style>
 
 /* open-sans-regular - latin */
@@ -181,7 +181,7 @@ html, body {
 			<img class="apprunner_icon" src="{{ full_url ~ 'static/apprunner_icon.svg' }}" />
 		</div>
 
-		<h1>And we're live!</h1>
+		<h1>And we're live! V2</h1>
 		<div class="metadata">
 			<p>
         {% if ( '0.0' in full_url or 'localhost' in full_url )  %}


### PR DESCRIPTION
The App relies on the starlette module which relies of submodules not specified on the requirements.txt
When App Runner builds the app its retrieves new versions of the submodules using PIP, the app then fails to start due to code breaking-changes. 

Specifing older versions of Jinja 2 and MarkupSafe addresses those issues and App Runner its able to compile and start the app correctly.

Jinja2==2.11.3
MarkupSafe==1.1.1