### PR TITLE
Remove unsafe usage of `eval`

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,21 +75,21 @@ def generate_avatar_image():
         return random.choice(list(enum_))
 
     # Make a random customization selection from custom arrays
-    def rc(customization, array):
-        return eval("py_avataaars." + customization + "." +  random.choice(array))
+    def rc(enum_, array):
+        return enum_[random.choice(array)]
 
     avatar = py_avataaars.PyAvataaar(
         style=py_avataaars.AvatarStyle.CIRCLE,
-        background_color=rc("Color", custom_circle_colors),
+        background_color=rc(py_avataaars.Color, custom_circle_colors),
         skin_color=r(py_avataaars.SkinColor),
         hair_color=r(py_avataaars.HairColor),
         facial_hair_type=r(py_avataaars.FacialHairType),
         facial_hair_color=r(py_avataaars.HairColor),
         top_type=r(py_avataaars.TopType),
         hat_color=r(py_avataaars.Color),
-        mouth_type=rc("MouthType", custom_mouth_types),
-        eye_type=rc("EyesType", custom_eye_types),
-        eyebrow_type=rc("EyebrowType", custom_eyebrow_types),
+        mouth_type=rc(py_avataaars.MouthType, custom_mouth_types),
+        eye_type=rc(py_avataaars.EyesType, custom_eye_types),
+        eyebrow_type=rc(py_avataaars.EyebrowType, custom_eyebrow_types),
         nose_type=r(py_avataaars.NoseType),
         accessories_type=r(py_avataaars.AccessoriesType),
         clothe_type=r(py_avataaars.ClotheType),

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ global_state = {
     "INITIALIZED": False
 }
 
-logging.basicConfig(stream=sys.stdout, level=eval('logging.' + getenv('LOG_LEVEL', 'INFO')))
+logging.basicConfig(stream=sys.stdout, level=getenv('LOG_LEVEL', 'INFO').upper())
 logging.debug('Log level is set to DEBUG.')
 
 # Generate and save a local avatar image


### PR DESCRIPTION
## Summary

using `eval()` is generally considered to be avoided, due to its security vulnerability. 
there are total 2 usage of `eval` in `app.py`, and both are not needed since

https://github.com/aws-containers/hello-app-runner/blob/f59d2cc56e65ae3aa4cceb85e8b61f6c15378860/app.py#L24
[basicConfig accepts string literal as log level](https://gist.github.com/juanpabloaj/3e6a41f683c1767c17824811db01165b), and

https://github.com/aws-containers/hello-app-runner/blob/f59d2cc56e65ae3aa4cceb85e8b61f6c15378860/app.py#L78-L79
enums can be accessed via array indexing


## Security Vulnerabilities

```py
export LOG_LEVEL='__builtins__["exec"]("print(\"hi\")")'

In [1]: import logging
   ...: from os import getenv
   ...: 
   ...: print(getenv('LOG_LEVEL', 'INFO'))
   ...: eval('logging.' + getenv('LOG_LEVEL', 'INFO'))
__builtins__["exec"]("print(\"hi\")")
hi
```
exec's content could have been `ls -al`, `import os;os.system('rm -rf')`, etc.

## Furthur read

[basicConfig()](https://github.com/python/cpython/blob/f10f503b24a35a43910a632ee50c7568bedd6664/Lib/logging/__init__.py#L2142-L2144) uses [setlevel()](https://github.com/python/cpython/blob/f10f503b24a35a43910a632ee50c7568bedd6664/Lib/logging/__init__.py#L982-L986), which accepts[ string literal as key from version 3.2](https://docs.python.org/3/library/logging.html#logging.Logger.setLevel). it uses [_checklevel()](https://github.com/python/cpython/blob/f10f503b24a35a43910a632ee50c7568bedd6664/Lib/logging/__init__.py#L208-L218) internally, which uses this [dictionary](https://github.com/python/cpython/blob/f10f503b24a35a43910a632ee50c7568bedd6664/Lib/logging/__init__.py#L115-L124) to determine its logging level.